### PR TITLE
Fix: pin just-the-docs to ~> 0.10.0 to fix SCSS build error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
 gem "jekyll", "~> 4.3"
-gem "just-the-docs", "~> 0.10"
+gem "just-the-docs", "~> 0.10.0"
 
 group :jekyll_plugins do
   gem "jekyll-seo-tag"


### PR DESCRIPTION
## Problem

GitHub Actions build was failing with:

```
Error: Can't find stylesheet to import.
Conversion error: Jekyll::Converters::Scss encountered an error while converting 'assets/css/just-the-docs-default.scss'
```

`just-the-docs 0.12.0` migrated its SCSS to the `@use`/`@forward` module system, which is incompatible with the legacy `@import` entrypoint used in `assets/css/just-the-docs-default.scss`.

## Fix

Pin `just-the-docs` to `~> 0.10.0` (restricts to 0.10.x only, which still uses `@import`).

| Before | After |
|--------|-------|
| `gem "just-the-docs", "~> 0.10"` (resolved to 0.12.0) | `gem "just-the-docs", "~> 0.10.0"` (resolves to 0.10.x) |

## Test plan

- [ ] Verify GitHub Actions build passes
- [ ] Confirm site deploys successfully to GitHub Pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)