### PR TITLE
Fix: remove invalid color_scheme causing SCSS build failure

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,7 +18,6 @@ plugins:
   - jekyll-feed
 
 # ─── Just the Docs settings ──────────────────────────────────────────────────
-color_scheme: default
 search_enabled: true
 
 search:


### PR DESCRIPTION
## Root Cause

`_config.yml` had `color_scheme: default` which caused just-the-docs to try importing a non-existent `_sass/color_schemes/default.scss`:

```
Error: Can't find stylesheet to import.
7 │ @import "./color_schemes/default";
```

just-the-docs only has two built-in color schemes: light (implicit, no setting needed) and `dark`. `default` is not a valid value.

## Fix

Remove `color_scheme: default` — the theme automatically uses the light scheme without any configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)